### PR TITLE
Add a State Handler base node

### DIFF
--- a/addons/nodot/characters/CharacterExtension3D.gd
+++ b/addons/nodot/characters/CharacterExtension3D.gd
@@ -1,17 +1,9 @@
 # A base node to add extension logic to NodotCharacter3D
-class_name CharacterExtensionBase3D extends Nodot
+class_name CharacterExtensionBase3D extends StateHandler
 
-## Enable/disable this node.
-@export var enabled : bool = true
 ## The NodotCharacter3D to apply this node to
 @export var character: NodotCharacter3D
-## Run action even when the state is unhandled
-@export var action_unhandled_states: bool = false
 
-var is_editor: bool = Engine.is_editor_hint()
-var sm: StateMachine
-var handled_states: Array[String] = []
-var state_ids: Dictionary = {}
 var direction: Vector3 = Vector3.ZERO
 var third_person_camera: ThirdPersonCamera
 var active_camera: Camera3D
@@ -29,34 +21,6 @@ func _enter_tree():
 		third_person_camera = character.camera
 	
 	sm = character.sm
-	sm.connect("state_updated", state_updated)
-	
-func _physics_process(delta):
-	if is_editor or !enabled or !sm or sm.state < 0 or (!action_unhandled_states and !handles_state(sm.state)):
-		return
-		
-	action(delta)
-	
-func _input(event: InputEvent) -> void:
-	if !InputManager.enabled:
-		return
-		
-	input(event)
-
-## Registers a set of states that the node handles
-func register_handled_states(new_states: Array[String]):
-	for state_name in new_states:
-		var state_id = sm.register_state(state_name)
-		state_ids[state_name] = state_id
-		handled_states.append(state_name)
-
-## Checks whether this node handles a certain state
-func handles_state(state: Variant) -> bool:
-	if state is String:
-		return handled_states.has(state)
-	if state is int:
-		return state_ids.values().has(state)
-	return false
 
 ## Turn to face the target. Essentially lerping look_at
 func face_target(target_position: Vector3, weight: float) -> void:
@@ -68,15 +32,3 @@ func face_target(target_position: Vector3, weight: float) -> void:
 	# Then lerp the next rotation
 	var target_rot = character.rotation
 	character.rotation.y = lerp_angle(initial_rotation.y, target_rot.y, weight)
-	
-## Extend this placeholder. This is where your logic will be run every physics frame.
-func action(delta: float) -> void:
-	pass
-
-## Extend this placeholder. This is where your logic will be run for every input.
-func input(event: InputEvent) -> void:
-	pass
-	
-## Extend this placeholder. This is triggered whenever the character state is updated.
-func state_updated(old_state: int, new_state: int) -> void:
-	pass

--- a/addons/nodot/characters/Locomotion3D/CharacterCrouch3D.gd
+++ b/addons/nodot/characters/Locomotion3D/CharacterCrouch3D.gd
@@ -12,7 +12,7 @@ class_name CharacterCrouch3D extends CharacterExtensionBase3D
 
 var shape_initial_height: float
 
-func _ready():
+func ready():
 	if !enabled:
 		return
 	
@@ -37,7 +37,7 @@ func state_updated(old_state: int, new_state: int) -> void:
 		collision_shape.shape.height = shape_initial_height
 		sm.set_state(state_ids["idle"])
 
-func action(delta: float) -> void:
+func physics(delta: float) -> void:
 	if Input.is_action_pressed(crouch_action):
 		sm.set_state(state_ids["crouch"])
 	else:

--- a/addons/nodot/characters/Locomotion3D/CharacterCrouch3D.gd
+++ b/addons/nodot/characters/Locomotion3D/CharacterCrouch3D.gd
@@ -5,12 +5,17 @@ class_name CharacterCrouch3D extends CharacterExtensionBase3D
 @export var collision_shape: CollisionShape3D
 ## The new height of the collision shape
 @export var crouch_height: float = 1.0
+## The associated character mover
+@export var character_mover: CharacterMover3D
+## The new movement speed
+@export var movement_speed: float = 1.0
 
 @export_subgroup("Input Actions")
 ## The input action name for crouching
 @export var crouch_action: String = "crouch"
 
 var shape_initial_height: float
+var initial_movement_speed: float = 5.0
 
 func ready():
 	if !enabled:
@@ -29,12 +34,19 @@ func ready():
 	
 	if collision_shape and collision_shape.shape and collision_shape.shape is CapsuleShape3D:
 		shape_initial_height = collision_shape.shape.height
+		
+	if character_mover:
+		initial_movement_speed = character_mover.movement_speed
 
 func state_updated(old_state: int, new_state: int) -> void:
 	if new_state == state_ids["crouch"]:
 		collision_shape.shape.height = crouch_height
+		if character_mover:
+			character_mover.movement_speed = movement_speed
 	elif new_state == state_ids["stand"]:
 		collision_shape.shape.height = shape_initial_height
+		if character_mover:
+			character_mover.movement_speed = initial_movement_speed
 		sm.set_state(state_ids["idle"])
 
 func physics(delta: float) -> void:

--- a/addons/nodot/characters/Locomotion3D/CharacterJump3D.gd
+++ b/addons/nodot/characters/Locomotion3D/CharacterJump3D.gd
@@ -8,7 +8,7 @@ class_name CharacterJump3D extends CharacterExtensionBase3D
 ## The input action name for jumping
 @export var jump_action: String = "jump"
 
-func _ready():
+func ready():
 	if !enabled:
 		return
 	
@@ -31,7 +31,7 @@ func state_updated(old_state: int, new_state: int) -> void:
 func jump() -> void:
 	character.velocity.y = jump_velocity
 
-func action(delta: float) -> void:
+func physics(delta: float) -> void:
 	if !character._is_on_floor():
 		return
 		

--- a/addons/nodot/characters/Locomotion3D/CharacterMover3D.gd
+++ b/addons/nodot/characters/Locomotion3D/CharacterMover3D.gd
@@ -39,7 +39,7 @@ class_name CharacterMover3D extends CharacterExtensionBase3D
 var sprint_speed = false
 var third_person_camera_container: Node3D
 
-func _ready():
+func ready():
 	if !enabled:
 		return
 	
@@ -75,7 +75,7 @@ func get_movement_speed(delta: float) -> float:
 		final_speed = movement_speed * sprint_speed_multiplier
 	return final_speed * delta * 100
 
-func action(delta: float) -> void:
+func physics(delta: float) -> void:
 	if character.input_enabled:
 		var input_dir = Input.get_vector(left_action, right_action, up_action, down_action)
 		var basis: Basis

--- a/addons/nodot/characters/Locomotion3D/CharacterSwim3D.gd
+++ b/addons/nodot/characters/Locomotion3D/CharacterSwim3D.gd
@@ -72,7 +72,7 @@ func add_action_to_input_map(action_name, default_key):
 	InputMap.action_add_event(action_name, input_key)
 
 
-func _ready():
+func ready():
 	if "camera" in character:
 		camera = character.camera
 		
@@ -96,7 +96,7 @@ func _ready():
 		third_person_camera_container = third_person_camera.get_parent()
 
 
-func action(delta: float) -> void:
+func physics(delta: float) -> void:
 	if !is_submerged: return
 	check_head_submerged()
 	

--- a/addons/nodot/physics/Mover3D.gd
+++ b/addons/nodot/physics/Mover3D.gd
@@ -30,8 +30,20 @@ signal movement_ended
 ## Time until origin
 @export var time_to_origin: float = 1.0
 ## Transition type (https://docs.godotengine.org/en/4.0/classes/class_tween.html)
-@export_enum("TRANS_LINEAR", "TRANS_SINE", "TRANS_QUINT", "TRANS_QUART", "TRANS_QUAD", "TRANS_EXPO", "TRANS_ELASTIC", "TRANS_CUBIC", "TRANS_CIRC", "TRANS_BOUNCE", "TRANS_BACK") var transition_type: int = 0
-
+@export_enum(
+	"TRANS_LINEAR",
+	"TRANS_SINE",
+	"TRANS_QUINT",
+	"TRANS_QUART",
+	"TRANS_QUAD",
+	"TRANS_EXPO",
+	"TRANS_ELASTIC",
+	"TRANS_CUBIC",
+	"TRANS_CIRC",
+	"TRANS_BOUNCE",
+	"TRANS_BACK"
+)
+var transition_type: int = 0
 
 var original_position: Vector3
 var original_rotation: Vector3
@@ -42,10 +54,10 @@ func _ready():
 	if target_node:
 		original_position = target_node.global_position
 		original_rotation = target_node.rotation
-	
+
 	if auto_start:
 		action()
-	
+
 
 ## Perform the move toggling between destination and origin
 func action():
@@ -67,13 +79,13 @@ func deactivate():
 
 
 func move_to_destination():
-	
 	var final_destination_position = destination_position
 	if relative_destination_position:
 		final_destination_position = original_position + destination_position
-	
-	if final_destination_position == global_position: return
-	
+
+	if final_destination_position == global_position:
+		return
+
 	activated = true
 	var destination_tween = _create_tween(_on_destination_reached)
 	var destination_rotation_radians = Vector3(
@@ -102,8 +114,9 @@ func move_to_destination():
 
 
 func move_to_origin():
-	if global_position == original_position: return
-	
+	if global_position == original_position:
+		return
+
 	activated = false
 	var origin_tween = _create_tween(_on_origin_reached)
 	if original_position:

--- a/addons/nodot/utility/StateHandler.gd
+++ b/addons/nodot/utility/StateHandler.gd
@@ -1,0 +1,73 @@
+## A node to handle and control events from a state machine
+class_name StateHandler extends Nodot
+
+## Enable/disable this node.
+@export var enabled : bool = true
+## The StateMachine to attach this handler to
+@export var sm: StateMachine
+## Run process/physics even when the state is unhandled
+@export var ignore_handled_states: bool = false
+
+var is_editor: bool = Engine.is_editor_hint()
+var handled_states: Array[String] = []
+var state_ids: Dictionary = {}
+
+func _ready():
+	if !enabled:
+		return
+		
+	sm.connect("state_updated", state_updated)
+	ready()
+	
+func _physics_process(delta):
+	if is_editor or !enabled or !sm or sm.state < 0 or (!ignore_handled_states and !handles_state(sm.state)):
+		return
+		
+	physics(delta)
+	
+func _process(delta):
+	if is_editor or !enabled or !sm or sm.state < 0 or (!ignore_handled_states and !handles_state(sm.state)):
+		return
+		
+	process(delta)
+	
+func _input(event: InputEvent) -> void:
+	if !InputManager.enabled:
+		return
+		
+	input(event)
+
+## Registers a set of states that the node handles
+func register_handled_states(new_states: Array[String]):
+	for state_name in new_states:
+		var state_id = sm.register_state(state_name)
+		state_ids[state_name] = state_id
+		handled_states.append(state_name)
+
+## Checks whether this node handles a certain state
+func handles_state(state: Variant) -> bool:
+	if state is String:
+		return handled_states.has(state)
+	if state is int:
+		return state_ids.values().has(state)
+	return false
+	
+## Extend this placeholder. This is where your logic will be run when the node becomes ready.
+func ready() -> void:
+	pass
+	
+## Extend this placeholder. This is where your logic will be run every physics frame.
+func physics(delta: float) -> void:
+	pass
+	
+## Extend this placeholder. This is where your logic will be run every process frame.
+func process(delta: float) -> void:
+	pass
+
+## Extend this placeholder. This is where your logic will be run for every input.
+func input(event: InputEvent) -> void:
+	pass
+	
+## Extend this placeholder. This is triggered whenever the character state is updated.
+func state_updated(old_state: int, new_state: int) -> void:
+	pass


### PR DESCRIPTION
Introduces a new base node, the StateHandler. The StateHandler is a node that can handle and control events from a state machine. It provides a base class for custom nodes that need to react to state machine events.

The StateHandler is designed to be used in conjunction with the existing NodotCharacter3D class. It can be used to add custom logic to the character's state machine.

This change includes a refactoring of the existing CharacterExtensionBase3D class to inherit from the new StateHandler node. The CharacterExtensionBase3D class is now a more specialized class that can be used to add custom logic to the character's state machine.

Overall, this change will make it easier to add custom logic to the character's state machine, and will improve the overall flexibility and extensibility of the project.

Closes #100 and #62