### PR TITLE
Fall damage

### DIFF
--- a/addons/nodot/characters/FirstPerson/FirstPersonCharacter.gd
+++ b/addons/nodot/characters/FirstPerson/FirstPersonCharacter.gd
@@ -84,7 +84,6 @@ func _physics_process(delta: float) -> void:
 		if on_floor:
 			var falling_velocity = abs(previous_velocity)
 			var damage = falling_velocity * fall_damage_multiplier
-			print(damage)
 			if damage > minimum_fall_damage:
 				health.add_health(-damage)
 				emit_signal("fall_damage", damage)


### PR DESCRIPTION
Adds fall damage to the game. When the character falls from a certain height, they will take damage proportional to the velocity at which they hit the ground. This will add a new level of realism to the game and make it more challenging for players.

The fall damage is implemented as a new signal, "fall_damage", which is emitted when the character hits the ground at a high velocity. The amount of damage inflicted is determined by the character's velocity and a configurable fall damage multiplier. A minimum fall damage can be set as well to prevent players from taking damage when falling from small heights.

This change will improve the gameplay experience by making it more challenging and realistic. It will also add a new level of strategy to the game, as players will need to be careful when jumping from high places to avoid taking damage.

Closes #66