### PR TITLE
Environment impact damage

### DIFF
--- a/addons/nodot/characters/ThirdPerson/ThirdPersonCamera.gd
+++ b/addons/nodot/characters/ThirdPerson/ThirdPersonCamera.gd
@@ -38,6 +38,9 @@ func _ready() -> void:
 
 
 func _physics_process(delta) -> void:
+	if !current:
+		return
+		
 	if raycast:
 		if raycast.is_colliding() and !raycast.hit_from_inside:
 			var collider = raycast.get_collider()

--- a/addons/nodot/interaction/RigidBreakable3D.gd
+++ b/addons/nodot/interaction/RigidBreakable3D.gd
@@ -45,7 +45,7 @@ func _enter_tree() -> void:
 
 
 func _physics_process(delta: float) -> void:
-	if contact_monitor and !angular_velocity.is_zero_approx() and get_contact_count() > 0:
+	if contact_monitor and get_contact_count() > 0:
 		var total_velocity: float = (
 			abs(linear_velocity.x) + abs(linear_velocity.y) + abs(linear_velocity.z)
 		)

--- a/addons/nodot/physics/Mover3D.gd
+++ b/addons/nodot/physics/Mover3D.gd
@@ -135,6 +135,10 @@ func move_to_origin():
 	origin_tween.play()
 	emit_signal("moving_to_origin")
 	emit_signal("movement_started")
+	
+func reset() -> void:
+	target_node.global_position = original_position
+	target_node.rotation = original_rotation
 
 
 func _create_tween(callback: Callable) -> Tween:


### PR DESCRIPTION
Addresses an issue related to environment impact damage in our project. 

For the ThirdPersonCamera, I have added a check to ensure that the camera only processes physics if there is a valid target.

For RigidBreakable3D, I have modified the condition for checking angular velocity. Previously, the condition checked for non-zero angular velocity and at least one contact. This prevented damage when the object isn't moving. By removing the check, the object can now be damaged by objects hitting it.

In the Mover3D node, I have added a `reset` function that resets the position and rotation of the target node to their original values. This provides a convenient way to loop animations.

Closes #109