### PR TITLE
Added Functions for Camera Updates in Orthographic Projection

### DIFF
--- a/addons/nodot/camera/IsometricCamera3D.gd
+++ b/addons/nodot/camera/IsometricCamera3D.gd
@@ -47,6 +47,8 @@ func _init():
 	if projection == PROJECTION_ORTHOGONAL:
 		zoom_in = zoom_in_orthogonal
 		zoom_out = zoom_out_orthogonal
+	else:
+		push_error("Cannot set zoom functionality, unsupported Camera3D projection setting: %s" % projection)
 
 func _ready():
 	global_position.y = height


### PR DESCRIPTION
# Introduction
I introduced nodot into a current Godot project to take advantage of the RTS controls. In my testing, I found that the camera zoom doesn't work when the `Camera3D`'s [`Projection`](https://docs.godotengine.org/en/stable/classes/class_camera3d.html#class-camera3d-property-projection) is set to `Orthogonal`, which is the perspective that I'm considering for my current project. In this PR, I add some functionality that adds additional zoom functions depending on the camera style and sets the relevant zoom functionality based on how the camera is configured on `_init`.